### PR TITLE
Switch to libsodium

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,13 @@
         "@octokit/plugin-retry": "^3.0.9",
         "@octokit/plugin-throttling": "^3.6.2",
         "js-yaml": "^4.1.0",
-        "tweetsodium": "^0.0.5"
+        "libsodium-wrappers": "^0.7.10"
       },
       "devDependencies": {
         "@types/eslint": "^8.4.1",
         "@types/jest": "^27.4.1",
         "@types/js-yaml": "^4.0.5",
+        "@types/libsodium-wrappers": "^0.7.9",
         "@types/node": "^17.0.23",
         "@typescript-eslint/eslint-plugin": "^5.18.0",
         "@typescript-eslint/parser": "^5.18.0",
@@ -1311,6 +1312,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "node_modules/@types/libsodium-wrappers": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+      "integrity": "sha512-LisgKLlYQk19baQwjkBZZXdJL0KbeTpdEnrAfz5hQACbklCY0gVFnsKUyjfNWF1UQsCSjw93Sj5jSbiO8RPfdw==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "17.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
@@ -1851,11 +1858,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
-    },
-    "node_modules/blakejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
-      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
@@ -4699,6 +4701,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libsodium": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
+      "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz",
+      "integrity": "sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==",
+      "dependencies": {
+        "libsodium": "^0.7.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -6043,20 +6058,6 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-    },
-    "node_modules/tweetsodium": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/tweetsodium/-/tweetsodium-0.0.5.tgz",
-      "integrity": "sha512-T3aXZtx7KqQbutTtBfn+P5By3HdBuB1eCoGviIrRJV2sXeToxv2X2cv5RvYqgG26PSnN5m3fYixds22Gkfd11w==",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "tweetnacl": "^1.0.1"
       }
     },
     "node_modules/type-check": {
@@ -7440,6 +7441,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/libsodium-wrappers": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+      "integrity": "sha512-LisgKLlYQk19baQwjkBZZXdJL0KbeTpdEnrAfz5hQACbklCY0gVFnsKUyjfNWF1UQsCSjw93Sj5jSbiO8RPfdw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "17.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
@@ -7808,11 +7815,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
-    },
-    "blakejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
-      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
     },
     "bottleneck": {
       "version": "2.19.5",
@@ -9966,6 +9968,19 @@
         "type-check": "~0.4.0"
       }
     },
+    "libsodium": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
+      "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
+    },
+    "libsodium-wrappers": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz",
+      "integrity": "sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==",
+      "requires": {
+        "libsodium": "^0.7.0"
+      }
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -10959,20 +10974,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
-    },
-    "tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-    },
-    "tweetsodium": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/tweetsodium/-/tweetsodium-0.0.5.tgz",
-      "integrity": "sha512-T3aXZtx7KqQbutTtBfn+P5By3HdBuB1eCoGviIrRJV2sXeToxv2X2cv5RvYqgG26PSnN5m3fYixds22Gkfd11w==",
-      "requires": {
-        "blakejs": "^1.1.0",
-        "tweetnacl": "^1.0.1"
-      }
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -36,12 +36,13 @@
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^3.6.2",
     "js-yaml": "^4.1.0",
-    "tweetsodium": "^0.0.5"
+    "libsodium-wrappers": "^0.7.10"
   },
   "devDependencies": {
     "@types/eslint": "^8.4.1",
     "@types/jest": "^27.4.1",
     "@types/js-yaml": "^4.0.5",
+    "@types/libsodium-wrappers": "^0.7.9",
     "@types/node": "^17.0.23",
     "@typescript-eslint/eslint-plugin": "^5.18.0",
     "@typescript-eslint/parser": "^5.18.0",

--- a/src/encrypt.ts
+++ b/src/encrypt.ts
@@ -1,10 +1,12 @@
-import tweetsodium from "tweetsodium"; // eslint-disable-line import/default
+import libsodium from "libsodium-wrappers";
 
-export function encrypt(publicKey: string, message: string) {
+export async function encrypt(publicKey: string, message: string): Promise<string> {
   const messageBytes = Buffer.from(message);
   const keyBytes = Buffer.from(publicKey, "base64");
+  
+  await libsodium.ready;
 
-  const encryptedBytes = tweetsodium.seal(messageBytes, keyBytes);
+  const encryptedBytes = libsodium.crypto_box_seal(messageBytes, keyBytes);
 
   const encrypted = Buffer.from(encryptedBytes).toString("base64");
 

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -31,7 +31,7 @@ export async function setOrDeleteSecret(environment: SecretEnvironment, owner: s
     owner,
     repo,
   });
-  const encryptedValue = encrypt(publicKey.key, value);
+  const encryptedValue = await encrypt(publicKey.key, value);
 
   await setSecret({
     environment,


### PR DESCRIPTION
This moves us over to `libsodium` now that `tweetsodium` is [unmaintained and deprecated in favor of this library](https://github.com/jedisct1/libsodium.js/issues/297).

Due to an issue with webpack/ncc bundling a cjs library to esm doesn't work. Running the bundled output results in the following error:

>ReferenceError: __dirname is not defined

Replacing `__dirname` in the bundled output with `process.cwd()` gets things working. Ideally this would be fixed in webpack/ncc, but libsodium packaging an esm build would also work. So until one of those things happens this can't be merged.

ref: https://github.com/jedisct1/libsodium.js/issues/263
ref: https://github.com/vercel/ncc/issues/749
